### PR TITLE
Fix session-map leaks behind the sts-2 GC death spiral

### DIFF
--- a/src/main/java/net/whydah/sts/health/AsyncHealthService.java
+++ b/src/main/java/net/whydah/sts/health/AsyncHealthService.java
@@ -65,6 +65,7 @@ public class AsyncHealthService implements Runnable {
     private final String applicationInstanceName;
     private final String version;
     private final AtomicLong healthComputeTimeMs = new AtomicLong(-1);
+    private final AtomicLong lastSuccessfulUpdateEpochMs = new AtomicLong(-1);
     private final boolean isExtendedInfoEnabled;
     private final AtomicReference<Ringbuffer<String>> threatSignalRingbufferRef = new AtomicReference<>();
     private final CountDownLatch readyLatch = new CountDownLatch(1);
@@ -121,6 +122,19 @@ public class AsyncHealthService implements Runnable {
         if (!activelyUpdatingCurrentHealth) {
             health.put("Status", "FAIL");
             health.put("errorMessage", "health-updater-thread is dead.");
+        }
+        // Honest staleness: a live-but-stuck updater (e.g. blocked on Hazelcast during
+        // GC pressure) must not present an old snapshot with a fresh 'now' as healthy.
+        long lastOkEpochMs = lastSuccessfulUpdateEpochMs.get();
+        if (lastOkEpochMs > 0) {
+            health.put("health-updated-at", Instant.ofEpochMilli(lastOkEpochMs).toString());
+            long staleMs = System.currentTimeMillis() - lastOkEpochMs;
+            long intervalMs = Duration.of(updateInterval, updateIntervalUnit).toMillis();
+            if (staleMs > 3 * intervalMs) {
+                health.put("Status", "FAIL");
+                health.put("errorMessage", "health data is stale: last successful update " + (staleMs / 1000)
+                        + "s ago (updater thread alive: " + activelyUpdatingCurrentHealth + ")");
+            }
         }
         health.put("now", Instant.now().toString());
         health.put("health-compute-time-ms", String.valueOf(healthComputeTimeMs));
@@ -189,6 +203,7 @@ public class AsyncHealthService implements Runnable {
                 // first health-update can be very slow, have to wait for Hazelcast init
                 updateHealth(currentHealth);
                 currentHealthSerialized.set(currentHealth.toPrettyString());
+                lastSuccessfulUpdateEpochMs.set(System.currentTimeMillis());
             } catch (Throwable t) {
                 log.warn("While setting health initialization message", t);
             }
@@ -215,6 +230,7 @@ public class AsyncHealthService implements Runnable {
                     if (changed) {
                         currentHealthSerialized.set(currentHealth.toPrettyString());
                     }
+                    lastSuccessfulUpdateEpochMs.set(System.currentTimeMillis());
                     Thread.sleep(Duration.of(updateInterval, updateIntervalUnit).toMillis());
                 } catch (Throwable t) {
                     log.error("While updating health", t);

--- a/src/main/java/net/whydah/sts/user/AuthenticatedUserTokenRepository.java
+++ b/src/main/java/net/whydah/sts/user/AuthenticatedUserTokenRepository.java
@@ -7,6 +7,9 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,6 +18,9 @@ import org.valuereporter.client.MonitorReporter;
 
 import com.hazelcast.cluster.Member;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MaxSizePolicy;
 import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
@@ -27,6 +33,7 @@ import net.whydah.sso.ddd.model.user.UserTokenId;
 import net.whydah.sso.user.mappers.UserTokenMapper;
 import net.whydah.sso.user.types.UserToken;
 import net.whydah.sts.ServiceStarter;
+import net.whydah.sts.application.AuthenticatedApplicationTokenRepository;
 import net.whydah.sts.config.AppConfig;
 import net.whydah.sts.threat.ThreatResource;
 import net.whydah.sts.user.statistics.UserSessionObservedActivity;
@@ -43,6 +50,7 @@ public class AuthenticatedUserTokenRepository {
 	//public static final long DEFAULT_USER_SESSION_TIME_IN_SECONDS;
 	public final static LogonTimeReporter logonReporter;
 	private static UserTokenMapMonitor mapMonitor;
+	private static ScheduledExecutorService cleanupScheduler;
     
     static Random random = new Random(100);
 
@@ -67,6 +75,18 @@ public class AuthenticatedUserTokenRepository {
 		}
 		hazelcastConfig.setProperty("hazelcast.logging.type", "slf4j");
 		//hazelcastConfig.getGroupConfig().setName("STS_HAZELCAST");
+
+		// Bound the lastSeen map. Entries are written on every token operation and
+		// were never removed, growing the heap without limit (PROD GC death spiral,
+		// sts-2, 2026-07). TTL is refreshed on every put, so active users never expire.
+		MapConfig lastSeenMapConfig = new MapConfig(appConfig.getProperty("gridprefix") + "lastSeenMap");
+		lastSeenMapConfig.setTimeToLiveSeconds((int) TimeUnit.DAYS.toSeconds(90));
+		lastSeenMapConfig.getEvictionConfig()
+				.setEvictionPolicy(EvictionPolicy.LRU)
+				.setMaxSizePolicy(MaxSizePolicy.PER_NODE)
+				.setSize(100_000);
+		hazelcastConfig.addMapConfig(lastSeenMapConfig);
+
 		HazelcastInstance tmpInstance;
 		try {
 			tmpInstance = Hazelcast.newHazelcastInstance(hazelcastConfig);
@@ -415,12 +435,42 @@ public class AuthenticatedUserTokenRepository {
             mapMonitor.start();
             log.info("UserTokenMapMonitor started");
         }
+		if (cleanupScheduler == null) {
+			long intervalMinutes = 60;
+			try {
+				String configured = new AppConfig().getProperty("sts.mapcleanup.interval.minutes");
+				if (configured != null && !configured.trim().isEmpty()) {
+					intervalMinutes = Long.parseLong(configured.trim());
+				}
+			} catch (Exception e) {
+				log.warn("Invalid sts.mapcleanup.interval.minutes, using default 60");
+			}
+			cleanupScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+				Thread t = new Thread(r, "TokenMapCleanup");
+				t.setDaemon(true);
+				return t;
+			});
+			cleanupScheduler.scheduleWithFixedDelay(() -> {
+				try {
+					cleanUserTokenMap();
+					AuthenticatedApplicationTokenRepository.cleanApplicationTokenMap();
+				} catch (Exception e) {
+					log.warn("Scheduled token map cleanup failed", e);
+				}
+			}, intervalMinutes, intervalMinutes, TimeUnit.MINUTES);
+			log.info("TokenMapCleanup scheduled every {} minutes", intervalMinutes);
+		}
 	}
 
 	public static void shutdownMonitor() {
 		if (mapMonitor != null) {
 			mapMonitor.stop();
 			log.info("UserTokenMapMonitor stopped");
+		}
+		if (cleanupScheduler != null) {
+			cleanupScheduler.shutdownNow();
+			cleanupScheduler = null;
+			log.info("TokenMapCleanup stopped");
 		}
 	}
 
@@ -454,20 +504,29 @@ public class AuthenticatedUserTokenRepository {
 
 
 	public static void cleanUserTokenMap() {
-		// OK... let us obfucscate/filter sessionsid's in signalEmitter field
+		int removedTokens = 0;
 		for (Map.Entry<String, UserToken> entry : activeusertokensmap.entrySet()) {
 			UserToken userToken = entry.getValue();
 			if (!userToken.isValid()) {
 				log.debug("Removed userTokenID {} - marked as invalid, userName: {}, getLastName: {}, getLifespanFormatted: {}  UserTokenXML:  {}", userToken.getUserTokenId(),userToken.getUserName(),userToken.getLastName(),userToken.getLifespanFormatted(), UserTokenMapper.toXML(userToken));
 				activeusertokensmap.remove(userToken.getUserTokenId());
-			} else {
-				// log.debug("Checked userTokenID {} - marked as valid, userName: {}, getLastName: {}, getLifespanFormatted: {}  UserTokenXML:  {}", userToken.getUserTokenId(),userToken.getUserName(),userToken.getLastName(),userToken.getLifespanFormatted(), UserTokenMapper.toXML(userToken));
-
+				if (userToken.getUserName() != null) {
+					active_username_usertokenids_map.remove(userToken.getUserName(), userToken.getUserTokenId());
+				}
+				removedTokens++;
 			}
-			//            if (new UserTokenLifespan(userToken.getLifespan()).getValueAsAbsoluteTimeInMilliseconds() < System.currentTimeMillis()) {
-			//                log.debug("Removed userTokenID {} - marked as timeout", userToken.getUserTokenId());
-			//                activeusertokensmap.remove(userToken.getUserTokenId());
-			//            }
+		}
+		// Sweep username entries pointing at usertokenids that no longer exist
+		int removedUsernameEntries = 0;
+		for (Map.Entry<String, String> entry : active_username_usertokenids_map.entrySet()) {
+			if (!activeusertokensmap.containsKey(entry.getValue())) {
+				active_username_usertokenids_map.remove(entry.getKey(), entry.getValue());
+				removedUsernameEntries++;
+			}
+		}
+		if (removedTokens > 0 || removedUsernameEntries > 0) {
+			log.info("cleanUserTokenMap removed {} expired usertokens and {} orphaned username entries - map sizes now: usertokens={}, usernames={}",
+					removedTokens, removedUsernameEntries, activeusertokensmap.size(), active_username_usertokenids_map.size());
 		}
 	}
 


### PR DESCRIPTION
## Summary
- **`lastSeenMap` unbounded growth** (the heap leak): written on every token operation, never evicted. Now bounded via Hazelcast `MapConfig` — 90-day TTL (refreshed on every put, so active users never expire) + 100k LRU cap per node. No call-site changes.
- **Dead cleaners wired up**: `cleanUserTokenMap()` and `cleanApplicationTokenMap()` had zero callers; expired tokens were only removed lazily on lookup, leaving abandoned sessions in the maps for the 6-month fallback lifespan. Both now run on a scheduled daemon thread (hourly by default, `sts.mapcleanup.interval.minutes` to override), started from `initializeDistributedMap()` and stopped in `shutdownMonitor()`.
- **`cleanUserTokenMap` leak fixed**: it removed the usertoken but left the `username → usertokenid` entry; now removes the pair and sweeps orphaned username entries.
- **Honest health staleness**: `/health` stamped a fresh `now` onto a possibly-stale cached snapshot and only failed if the updater thread was *dead* — an alive-but-stuck updater (the mid-GC-spiral case) looked healthy. It now reports `health-updated-at` and fails when the last successful update is older than 3 update intervals.

## Test plan
- [x] `mvn test` — 56 tests, 0 failures, 0 errors on the branch
- [x] Verified the one isolated-run failure (`AuthenticatedUserTokenRepositoryTest.updateDefaultUserSessionExtensionTime` static-mock/clinit ordering) reproduces identically on unmodified master — pre-existing, unrelated
- [ ] Deploy to a 1881 staging/secondary node and watch `UserLastSeenMapSize` / `AuthenticatedUserTokenMapSize` in `/health` trend flat instead of monotonically up

🤖 Generated with [Claude Code](https://claude.com/claude-code)